### PR TITLE
Add Outlook 2019 to the supported versions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Installation requirements:
 ==========================
  - .Net Framework 4.0
- - Installed Microsoft Outlook 2016, 2013 or 2010
+ - Installed Microsoft Outlook 2019, 2016, 2013 or 2010
  - For Outlook 2010 without SP you need to install the VSTO runtime:
    https://www.microsoft.com/en-us/download/details.aspx?id=48217
 


### PR DESCRIPTION
According to https://github.com/HoffmannTom/outlookbackupaddin/issues/23 and other issues, the Add-In should work with Outlook 2019. Should I also add something regarding the Add-In registration `BackupExecutor.exe /register` as well?

Thank you very much for the great Add-In, Best regards from Austria

Andreas, AlpenEDV